### PR TITLE
Update es-ES.json

### DIFF
--- a/locale/es-ES.json
+++ b/locale/es-ES.json
@@ -1,6 +1,6 @@
 {
-    "countProcess.failReason.numbersOnly": "**Este canal de chatear de conteo está en modo de sólo números.**",
-    "countProcess.failReason.doubleCount": "**No puedes contar dos números en una fila.**",
+    "countProcess.failReason.numbersOnly": "**Este canal de contar está en modo de solo números.**",
+    "countProcess.failReason.doubleCount": "**No puedes contar dos números seguidos.**",
     "countProcess.failReason.wrongNumber": "**Número incorrecto.**",
     "countProcess.warning.memberSaveUsed": "<@{authorId}> Has usado **1** de tus salvos. Te quedan **{savesLeft:g}**.",
     "countProcess.warning.guildSaveUsed": "<@{authorId}> Has usado **1** de tus salvados. Te quedan **{savesLeft:g}/2**.",
@@ -8,7 +8,7 @@
     "countProcess.warning.accountTooYoung": "Lo sentimos, su cuenta debe tener al menos `7` días de antigüedad para contar.",
     "countProcess.warning.waitForSomeoneElse": "Espera a que alguien más envíe **{nextNumber:,d}**.",
     "countProcess.failAlert.embedDescription": "Vota [here](https://countingbot.com/vote) para ganar salvos para que puedas seguir contando la próxima vez. Mira `{helpCmd}`.",
-    "countProcess.failAlert.messageContent": "<@{authorId}> LO ARRUINASTE EN **{number:,d}**!! El siguiente número es **1**. {failReason}",
+    "countProcess.failAlert.messageContent": "¡¡<@{authorId}> LO ARRUINASTE EN **{number:,d}**!! El siguiente número es **1**. {failReason}",
     "countProcess.newHighScore.messageContent": "¡Nuevo récord de puntuación de **{highScore:,d}**!",
 
     "messageDeleted.messageContent": "<@{userID}> ha eliminado su número: ```{deletedNumber:,d}```",


### PR DESCRIPTION
"Dos números en una fila" doesn't make sense in Spanish. It should be "dos números seguidos", not "dos números en una fila" (the current one translates "in a row" literally, like "two numbers in a line"). "Este canal de chatear de conteo está en modo de sólo números."->"Este canal de contar está en modo de solo números." The word should be "solo", not "sólo" (even Crowdin's spelling suggestions detect it). Besides, "canal de chatear de contar" is not natural (it literally translates as "channel for chatting of counting").
PS: I added "¡¡" in line 11 because the sentence ended with "!!", and exclamatory sentences in Spanish need to start with "¡" and end with "!".